### PR TITLE
feat: add mobile-first trading interface

### DIFF
--- a/src/components/trade/mobile/mobile-terminal-page.tsx
+++ b/src/components/trade/mobile/mobile-terminal-page.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { useMarketPrefsMigrations } from "@/hooks/markets/use-market-prefs-migrations";
+import { MobileHeader } from "./mobile-header";
+import { MobileBottomNav } from "./mobile-bottom-nav";
+import { MobileTradeView } from "./mobile-trade-view";
+import { MobilePositionsView } from "./mobile-positions-view";
+import { MobileMarketsView } from "./mobile-markets-view";
+
+type MobileView = "trade" | "positions" | "markets";
+
+export function MobileTerminalPage() {
+	useMarketPrefsMigrations();
+	const [activeView, setActiveView] = useState<MobileView>("trade");
+
+	return (
+		<div className="bg-background text-foreground h-screen w-full flex flex-col font-mono">
+			<MobileHeader />
+
+			<main className="flex-1 min-h-0 overflow-hidden">
+				{activeView === "trade" && <MobileTradeView />}
+				{activeView === "positions" && <MobilePositionsView />}
+				{activeView === "markets" && <MobileMarketsView />}
+			</main>
+
+			<MobileBottomNav activeView={activeView} onViewChange={setActiveView} />
+		</div>
+	);
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,10 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { TradeTerminalPage } from "@/components/trade/trade-terminal-page";
+import { ResponsiveTerminalPage } from "@/components/trade/responsive-terminal-page";
 import { ROUTE_SEO } from "@/constants/app";
 import { buildPageHead } from "@/lib/seo";
 
 export const Route = createFileRoute("/")({
 	head: () =>
 		buildPageHead(ROUTE_SEO.TRADE),
-	component: TradeTerminalPage,
+	component: ResponsiveTerminalPage,
 });


### PR DESCRIPTION
Add responsive mobile layout foundation

- Create responsive wrapper that detects screen size
- Add mobile terminal page structure
- Implement bottom navigation pattern
- Use drawer-based order entry
- Add touch-friendly controls (48px minimum)

Closes #15

Generated with [Claude Code](https://claude.ai/code)