### PR TITLE
fix: align boneyard-js lockfile specifier with package.json pin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
         specifier: 7.0.1
         version: 7.0.1
       boneyard-js:
-        specifier: ^1.7.5
+        specifier: 1.7.5
         version: 1.7.5(react@19.2.0)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
       class-variance-authority:
         specifier: 0.7.1


### PR DESCRIPTION
## Summary
- `pnpm-lock.yaml` had `specifier: ^1.7.5` for `boneyard-js` but `apps/terminal/package.json` was pinned to exact `1.7.5` in commit 6378f1a
- pnpm's frozen lockfile mode (used in CI/Vercel) rejects this mismatch, causing the Vercel build to fail
- One-char fix: remove the `^` from the lockfile specifier to match the manifest

## Test plan
- [ ] Vercel deployment succeeds after merge